### PR TITLE
Update for Pawnmorpher compatibility

### DIFF
--- a/A Dog Said... Animal Prosthetics 2/1.4/ModCompat/Pawnmorpher/Patches/Category_Patches_Pawnmorpher.xml
+++ b/A Dog Said... Animal Prosthetics 2/1.4/ModCompat/Pawnmorpher/Patches/Category_Patches_Pawnmorpher.xml
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="utf-8"?>
+
+<Patch>
+	<Operation Class="PatchOperationAdd">
+		<xpath>/Defs/RecipeDef[
+			@Name="ADS_Cat3" or
+			@Name="ADS_Cat2" or
+			@Name="ADS_Cat1"
+			]/recipeUsers</xpath>
+		<value>
+			<li>Chaofox</li>
+			<li>Chaoboar</li>
+			<li>Chaoboom</li>
+			<li>Chaocow</li>
+			<li>Chaodino</li>
+			<li>ChaofusionRhino</li>
+			<li>ChaomeldCow</li>
+			<li>ChaomeldDog</li>
+			<li>ChaomeldDragon</li>
+			<li>PM_Chaothrumbo</li>
+			<li>EtherHellhound</li>
+		</value>
+	</Operation>
+</Patch>

--- a/A Dog Said... Animal Prosthetics 2/1.5/ModCompat/Pawnmorpher/Patches/Category_Patches_Pawnmorpher.xml
+++ b/A Dog Said... Animal Prosthetics 2/1.5/ModCompat/Pawnmorpher/Patches/Category_Patches_Pawnmorpher.xml
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="utf-8"?>
+
+<Patch>
+	<Operation Class="PatchOperationAdd">
+		<xpath>/Defs/RecipeDef[
+			@Name="ADS_Cat3" or
+			@Name="ADS_Cat2" or
+			@Name="ADS_Cat1"
+			]/recipeUsers</xpath>
+		<value>
+			<li>Chaofox</li>
+			<li>Chaoboar</li>
+			<li>Chaoboom</li>
+			<li>Chaocow</li>
+			<li>Chaodino</li>
+			<li>ChaofusionRhino</li>
+			<li>ChaomeldCow</li>
+			<li>ChaomeldDog</li>
+			<li>ChaomeldDragon</li>
+			<li>PM_Chaothrumbo</li>
+			<li>EtherHellhound</li>
+		</value>
+	</Operation>
+</Patch>

--- a/A Dog Said... Animal Prosthetics 2/1.6/ModCompat/Pawnmorpher/Patches/Category_Patches_Pawnmorpher.xml
+++ b/A Dog Said... Animal Prosthetics 2/1.6/ModCompat/Pawnmorpher/Patches/Category_Patches_Pawnmorpher.xml
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="utf-8"?>
+
+<Patch>
+	<Operation Class="PatchOperationAdd">
+		<xpath>/Defs/RecipeDef[
+			@Name="ADS_Cat3" or
+			@Name="ADS_Cat2" or
+			@Name="ADS_Cat1"
+			]/recipeUsers</xpath>
+		<value>
+			<li>Chaofox</li>
+			<li>Chaoboar</li>
+			<li>Chaoboom</li>
+			<li>Chaocow</li>
+			<li>Chaodino</li>
+			<li>ChaofusionRhino</li>
+			<li>ChaomeldCow</li>
+			<li>ChaomeldDog</li>
+			<li>ChaomeldDragon</li>
+			<li>PM_Chaothrumbo</li>
+			<li>EtherHellhound</li>
+		</value>
+	</Operation>
+</Patch>

--- a/A Dog Said... Animal Prosthetics 2/About/About.xml
+++ b/A Dog Said... Animal Prosthetics 2/About/About.xml
@@ -39,6 +39,7 @@
 		<li>Maximilian.MoreThrumbos</li>
 		<li>spincrus.dinosauria</li>
 		<li>el.kenshifauna</li>
+		<li>tachyonite.pawnmorpherpublic</li>
 	</loadAfter>
 	<incompatibleWith>
 		<li>spoonshortage.adogsaidanimalprosthetics</li>

--- a/A Dog Said... Animal Prosthetics 2/LoadFolders.xml
+++ b/A Dog Said... Animal Prosthetics 2/LoadFolders.xml
@@ -29,6 +29,7 @@
 		<li IfModActive="Erin.Wildlife">1.4/ModCompat/Erin/Wildlife</li>
 		<li IfModActive="oblitus.housekeeperassistancecat">1.4/ModCompat/HousekeeperAssistanceCat</li>
 		<li IfModActive="onyxae.dragonsdescent">1.4/ModCompat/OttersHoldHands/DragonsDescent</li>
+		<li IfModActive="tachyonite.pawnmorpherpublic">1.4/ModCompat/Pawnmorpher</li>
 	</v1.4>
 	<v1.5>
 		<li>/</li>
@@ -64,6 +65,7 @@
 		<li IfModActive="choosechee.anomalyallies">1.5/ModCompat/ChimeraCreation</li>
 		<li IfModActive="el.kenshifauna">1.5/ModCompat/KenshiFauna</li>
 		<li IfModActive="abrolo.grimstone.beasts">1.5/ModCompat/GrimstoneBeasts</li>
+		<li IfModActive="tachyonite.pawnmorpherpublic">1.5/ModCompat/Pawnmorpher</li>
 	  </v1.5>
 	<v1.6>
 		<li>/</li>
@@ -100,5 +102,6 @@
 		<li IfModActive="el.kenshifauna">1.6/ModCompat/KenshiFauna</li>
 		<li IfModActive="abrolo.grimstone.beasts">1.6/ModCompat/GrimstoneBeasts</li>
 		<li IfModActive="spino.megafauna">1.6/ModCompat/Megafauna</li>
+		<li IfModActive="tachyonite.pawnmorpherpublic">1.6/ModCompat/Pawnmorpher</li>
 	  </v1.6>
 </loadFolders>


### PR DESCRIPTION
A simple update making ADS2 compatible with Pawnmorpher's chaoanimals. Tested with versions 1.4 through 1.6 of Rimworld. Pawnmorpher's Steam workshop page: https://steamcommunity.com/sharedfiles/filedetails/?id=1786466855